### PR TITLE
Make games_path_*.py independent per target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ CONVERT_ROM/rom/*
 *.pyc
 
 games_path.py
+games_path_*.py
 
 Yokoi*.3dsx
 Yokoi*.elf

--- a/CONVERT_ROM/source/crab_grab_game_processor.py
+++ b/CONVERT_ROM/source/crab_grab_game_processor.py
@@ -19,7 +19,7 @@ class CrabGrabGameProcessor(GameProcessor):
 		self.add_colour_indices()
 
 		# Combine the regular background with the Subtract, Overlay and Frame
-		updater = GamesPathUpdater()
+		updater = GamesPathUpdater(self.target_name)
 		target = updater.get_target(self.game_key)
 		game_folder = target.background_paths[0].parent
 

--- a/CONVERT_ROM/source/game_processor.py
+++ b/CONVERT_ROM/source/game_processor.py
@@ -62,7 +62,7 @@ class GameProcessor:
 		self.target_name: str = target_name
 
 	def load_info(self) -> bool:
-		updater = GamesPathUpdater()
+		updater = GamesPathUpdater(self.target_name)
 		target = updater.get_target(self.game_key)
 		if target is None:
 			print(f"Game '{self.game_key}' not found in games_path")
@@ -334,7 +334,7 @@ class GameProcessor:
 	
 	def multiscreen_conversion(self) -> None:
 		"""Placeholder for multiscreen conversion logic for this game."""
-		updater = GamesPathUpdater()
+		updater = GamesPathUpdater(self.target_name)
 		target = updater.get_target(self.game_key)
 
 		if target is None:
@@ -492,11 +492,11 @@ class GameProcessor:
 		Raises RuntimeError on failure.
 		"""
 
-		return load_games_path()
+		return load_games_path(self.target_name)
 
 	def _update_games_path_visual(self, out_svg: Path) -> None:
 		"""Replace this game's Visual entry in games_path.py with ``out_svg``"""
-		updater = GamesPathUpdater()
+		updater = GamesPathUpdater(self.target_name)
 
 		# games_path values are relative paths rooted at script_root.
 		# Keep that convention for the new visual path.

--- a/CONVERT_ROM/source/generate_games_path.py
+++ b/CONVERT_ROM/source/generate_games_path.py
@@ -714,7 +714,8 @@ def generate_games_path(target_name: str | None = None) -> bool:
 
     entries.sort(key=lambda item: item.key.lower())
 
-    destination = script_dir / "games_path.py"
+    destination_name = f"games_path_{profile.name}.py"
+    destination = script_dir / destination_name
     write_games_path(entries, script_dir, destination)
 
     print(f"Generated {len(entries)} games. Output -> {destination}")

--- a/CONVERT_ROM/source/spitball_sparky_game_processor.py
+++ b/CONVERT_ROM/source/spitball_sparky_game_processor.py
@@ -18,7 +18,7 @@ class SpitballSparkyGameProcessor(GameProcessor):
 		self.header_fraction: float = 0.15
 		self.add_colour_indices()
 
-		updater = GamesPathUpdater()
+		updater = GamesPathUpdater(self.target_name)
 		target = updater.get_target(self.game_key)
 		game_folder = target.background_paths[0].parent
 


### PR DESCRIPTION
Changes the games_path.py output of the rom generation scripts to be per target. i.e. games_path_3ds.py and games_path_rgds.py.

Both targets were sharing the same games_path.py file so could cause issues if you were building and making changes to different targets at the same time. Now they have their own games_path.py files.

Not a problem if you were just building one or the other, but a nice fix to avoid any issues.