### PR TITLE
 Virtual_Screen::set_img now checks whether the same texture path is …

### DIFF
--- a/source/virtual_i_o/3ds_screen.cpp
+++ b/source/virtual_i_o/3ds_screen.cpp
@@ -577,15 +577,27 @@ void Virtual_Screen::set_img(const std::string& path, const uint16_t* info
     memcpy(&vertex_data[index_start_texte+(nb_text_max+img_i)*6], curr_vertex.data(), curr_vertex.size() * sizeof(vertex)); 
     send_vbo();
     // textyre
-    if (img_texture[img_i].data) { C3D_TexDelete(&img_texture[img_i]); img_texture[img_i].data = nullptr;  }    
-    if (!loadTexture_file(path, &img_texture[img_i])) { printf("Erreur chargement texture segment !\n"); }
+    const bool same_texture = (img_texture[img_i].data != nullptr && img_texture_path[img_i] == path);
+    if (!same_texture) {
+        if (img_texture[img_i].data) {
+            C3D_TexDelete(&img_texture[img_i]);
+            img_texture[img_i].data = nullptr;
+        }
+        if (!loadTexture_file(path, &img_texture[img_i])) {
+            printf("Erreur chargement texture segment !\n");
+            img_texture_path[img_i].clear();
+        } else {
+            img_texture_path[img_i] = path;
+        }
+    }
     // set index for update
     if (std::find(indice_img.begin(),indice_img.end(),img_i) == indice_img.end()) { indice_img.push_back(img_i); }
 }
 
 void Virtual_Screen::delete_all_img(){
     for (size_t img_i = 0; img_i < indice_img.size(); img_i++) { 
-        if (img_texture[img_i].data) { C3D_TexDelete(&img_texture[img_i]); img_texture[img_i].data = nullptr;  }    
+        if (img_texture[img_i].data) { C3D_TexDelete(&img_texture[img_i]); img_texture[img_i].data = nullptr; }
+        img_texture_path[img_i].clear();
     }
     indice_img.resize(0);
 }

--- a/source/virtual_i_o/3ds_screen.h
+++ b/source/virtual_i_o/3ds_screen.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <cstdint>
+#include <string>
 #include "SM5XX/SM5XX.h"
 #include "std/segment.h"
 #include "std/settings.h"
@@ -48,6 +49,7 @@ class Virtual_Screen {
         C3D_Tex text_texture;
         C3D_Tex noise_texture;
         C3D_Tex img_texture[nb_img_interface_max];
+        std::string img_texture_path[nb_img_interface_max];
 
         std::vector<Segment> list_segment;
         uint32_t index_segment_screen[4];


### PR DESCRIPTION
ChatGPT seemed to come up with a reasonable reason why the game exit was slow for the rompack as it has to reread textures from the SD card. You can judge if this is a good fix or not...

_Virtual_Screen::set_img now checks whether the same texture path is already loaded for that img_i. If it is, it keeps the existing C3D_Tex, avoiding the expensive pack read on exit-to-menu._