### PR TITLE
Switch builds to default to rompacks

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,7 +6,7 @@ To build the application you will need to generate the assets/rompack first. See
 
 Building has only been tested on Windows.
 
-If you are building the applications yourself you can choose to build either an **embedded** or **rompack** build. The embedded build has all the assets and roms built into the application and the rompack build does not, which then requires the separate rompack to also be build and installed.
+If you are building the applications yourself you can choose to build either an **embedded** or **rompack** build. The embedded build has all the assets and roms built into the application and the rompack build does not, which then requires the separate rompack to also be built and installed.
 
 ## 3DS (devkitPro)
 
@@ -14,7 +14,7 @@ If you are building the applications yourself you can choose to build either an 
 
 - [devkitPro](https://devkitpro.org/wiki/Getting_Started) with **devkitARM**
 
-### Build (embedded)
+### Build (rompack build) (default)
 
 From the repo root:
 
@@ -23,16 +23,16 @@ From the repo root:
     - `make clean` (Optional)
 	- `make`
 
-### Build (rompack build)
+Output files include `rompack` in their names.
 
-This mode builds an app that loads everything from an external rompack on the SD card.
+### Build (embedded)
+
+This mode builds an app that includes ROMs/assets embedded in the application.
 
 - First build Game & Watch assets needed. See: [CONVERT_ROM/README.md](/CONVERT_ROM/README.md)
 - Builds both `.3dsx` and `.cia`:
     - `make clean` (Optional)
-    - `make ROMPACK_ONLY=1`
-
-Output files include `rompack` in their names.
+    - `make EMBEDDED=1`
 
 ## Android (Android Studio / Gradle)
 
@@ -45,5 +45,5 @@ Output files include `rompack` in their names.
 
 1. First build Game & Watch assets needed. See: [CONVERT_ROM/README.md](/CONVERT_ROM/README.md)
 2. Open the `android/` folder in Android Studio.
-3. Use **Build Variants** to select `embeddedDebug` or `rompackOnlyDebug`.
+3. Use **Build Variants** to select `rompackOnlyDebug` (default) or `embeddedDebug`.
 4. Build/run from Android Studio.

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ GRAPHICS	:=	gfx
 ROMFS		:=	romfs
 GFXBUILD	:=	$(ROMFS)/gfx
 
-# Set ROMPACK_ONLY=1 to build without embedded ROMs/graphics and rely on an external .ykp pack.
-ROMPACK_ONLY ?= 0
+# Set EMBEDDED=1 to build with embedded ROMs/graphics.
+# Default (EMBEDDED=0) builds without embedded assets and relies on an external .ykp pack.
+EMBEDDED ?= 0
 
 # Set SHOW_MSG_ROM=0 to build without show Warning rom data
 SHOW_MSG_ROM ?= 1
@@ -51,13 +52,13 @@ SHOW_MSG_ROM ?= 1
 # Bump this when the app expects newer pack contents (textures/layout/etc.).
 ROMPACK_CONTENT_VERSION_REQUIRED ?= 2
 
-# Extra defines for pack-only builds (appended after CFLAGS is set).
+# Extra defines for embedded/pack builds (appended after CFLAGS is set).
 ROMPACK_DEFINES ?=
 
 # Always define the required content version (applies when a pack is loaded).
 ROMPACK_DEFINES += -DYOKOI_ROMPACK_REQUIRED_CONTENT_VERSION=$(ROMPACK_CONTENT_VERSION_REQUIRED)
 
-ifneq ($(strip $(ROMPACK_ONLY)),0)
+ifeq ($(strip $(EMBEDDED)),0)
 	SOURCES := $(filter-out source/std/GW_ROM,$(SOURCES))
 	INCLUDES := $(filter-out source/std/GW_ROM,$(INCLUDES))
 	# Suffix output artifacts so pack-only builds are easy to distinguish.
@@ -68,7 +69,10 @@ ifneq ($(strip $(ROMPACK_ONLY)),0)
 	ROMFS := romfs
 	GFXBUILD := $(ROMFS)/gfx
 	ROMPACK_UI_GFXFILES := texte_3ds.t3s logo_pioupiou.t3s
-	ROMPACK_DEFINES += -DYOKOI_EXTERNAL_ROMPACK_ONLY
+endif
+
+ifneq ($(strip $(EMBEDDED)),0)
+	ROMPACK_DEFINES += -DYOKOI_EMBEDDED_ASSETS=1
 endif
 
 ifneq ($(strip $(SHOW_MSG_ROM)),0)
@@ -135,9 +139,9 @@ SHLISTFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.shlist)))
 GFXFILES	:=	$(foreach dir,$(GRAPHICS),$(notdir $(wildcard $(dir)/*.t3s)))
 BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
 
-	# In pack-only builds, only include minimal UI textures in romfs.
+	# In non-embedded builds, only include minimal UI textures in romfs.
 	# (Game textures come from the external .ykp pack.)
-	ifneq ($(strip $(ROMPACK_ONLY)),0)
+	ifeq ($(strip $(EMBEDDED)),0)
 		GFXFILES := $(ROMPACK_UI_GFXFILES)
 	endif
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,21 +44,22 @@ android {
     // - rompackOnly: ships without embedded ROMs/assets; requires an external .ykp pack at runtime.
     flavorDimensions += ['content']
     productFlavors {
-        embedded {
+        // Keep rompackOnly first so Android Studio tends to pick rompackOnlyDebug by default.
+        rompackOnly {
             dimension 'content'
-            buildConfigField 'boolean', 'ROMPACK_ONLY', 'false'
+            buildConfigField 'boolean', 'EMBEDDED', 'false'
             externalNativeBuild {
                 cmake {
-                    arguments '-DYOKOI_EXTERNAL_ROMPACK_ONLY=OFF'
+                    arguments '-DYOKOI_EMBEDDED_ASSETS=OFF'
                 }
             }
         }
-        rompackOnly {
+        embedded {
             dimension 'content'
-            buildConfigField 'boolean', 'ROMPACK_ONLY', 'true'
+            buildConfigField 'boolean', 'EMBEDDED', 'true'
             externalNativeBuild {
                 cmake {
-                    arguments '-DYOKOI_EXTERNAL_ROMPACK_ONLY=ON'
+                    arguments '-DYOKOI_EMBEDDED_ASSETS=ON'
                 }
             }
         }

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -4,7 +4,7 @@ project(yokoi_android LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(YOKOI_EXTERNAL_ROMPACK_ONLY "Build without compiled-in ROMs/assets; require external ROM pack at runtime" OFF)
+option(YOKOI_EMBEDDED_ASSETS "Build with compiled-in ROMs/assets (embedded build)" OFF)
 
 # Minimum external pack content version that this build accepts.
 # Bump this when the app expects newer pack contents (textures/layout/etc.).
@@ -31,7 +31,7 @@ file(GLOB_RECURSE YOKOI_GW_ROM_SRC
     "${YOKOI_ROOT}/source/std/GW_ROM_RGDS/*.cpp"
 )
 
-if(YOKOI_EXTERNAL_ROMPACK_ONLY)
+if(NOT YOKOI_EMBEDDED_ASSETS)
     set(YOKOI_GW_ROM_SRC "")
 endif()
 
@@ -63,8 +63,8 @@ add_library(yokoi SHARED
     ${YOKOI_GW_ROM_SRC}
 )
 
-if(YOKOI_EXTERNAL_ROMPACK_ONLY)
-    target_compile_definitions(yokoi PRIVATE YOKOI_EXTERNAL_ROMPACK_ONLY=1)
+if(YOKOI_EMBEDDED_ASSETS)
+    target_compile_definitions(yokoi PRIVATE YOKOI_EMBEDDED_ASSETS=1)
 endif()
 
 target_compile_definitions(yokoi PRIVATE YOKOI_ROMPACK_REQUIRED_CONTENT_VERSION=${YOKOI_ROMPACK_REQUIRED_CONTENT_VERSION})

--- a/android/app/src/main/java/com/retrovalou/yokoi/MainActivity.java
+++ b/android/app/src/main/java/com/retrovalou/yokoi/MainActivity.java
@@ -53,7 +53,7 @@ public final class MainActivity extends Activity {
     private RomPackImporter romPackImporter;
 
     private boolean isPackOnlyGated() {
-        return BuildConfig.ROMPACK_ONLY && (glView == null);
+        return !BuildConfig.EMBEDDED && (glView == null);
     }
 
     private File getDefaultRomPackPathPreferExternal() {
@@ -346,7 +346,7 @@ public final class MainActivity extends Activity {
                     public void onRomPackImported(File dest, boolean loadOk) {
                         if (loadOk) {
                             // If we started in "gated" mode (no GL/UI yet), bring up the main UI now.
-                            if (BuildConfig.ROMPACK_ONLY && glView == null) {
+                            if (!BuildConfig.EMBEDDED && glView == null) {
                                 startMainUi();
                             } else if (packOverlay != null) {
                                 packOverlay.setVisibility(View.GONE);
@@ -367,7 +367,7 @@ public final class MainActivity extends Activity {
 
         // In pack-only builds, do not create/render the emulator UI until we have a valid pack.
         // This prevents the menu/overlays from appearing behind the import screen.
-        if (BuildConfig.ROMPACK_ONLY && !packOk) {
+        if (!BuildConfig.EMBEDDED && !packOk) {
             showPackGateScreen();
             return;
         }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -65,7 +65,7 @@ static std::string g_pack_load_error;
 
 static constexpr const char* k3dsRomPackPath = "sdmc:/3ds/yokoi_pack_3ds.ykp";
 
-#if defined(YOKOI_EXTERNAL_ROMPACK_ONLY)
+#if !defined(YOKOI_EMBEDDED_ASSETS)
 static void show_pack_required_console(const std::string& err) {
     gfxInitDefault();
 
@@ -95,7 +95,7 @@ static void show_pack_required_console(const std::string& err) {
 
     gfxExit();
 }
-#endif // defined(YOKOI_EXTERNAL_ROMPACK_ONLY)
+#endif // !defined(YOKOI_EMBEDDED_ASSETS)
 
 static void show_pack_required_screen(Virtual_Screen& v_screen, const std::string& err) {
     v_screen.delete_all_text();
@@ -623,7 +623,7 @@ int main()
             g_pack_load_error.clear();
         }
 
-#if defined(YOKOI_EXTERNAL_ROMPACK_ONLY)
+#if !defined(YOKOI_EMBEDDED_ASSETS)
         if (!pack_ok) {
             show_pack_required_console(g_pack_load_error);
             return 0;

--- a/source/std/load_file.cpp
+++ b/source/std/load_file.cpp
@@ -2,7 +2,7 @@
 
 #include "gw_pack.h"
 
-#if !defined(YOKOI_EXTERNAL_ROMPACK_ONLY)
+#if defined(YOKOI_EMBEDDED_ASSETS)
     #if defined(__ANDROID__)
         #include "GW_ALL_rgds.h"
     #else
@@ -16,7 +16,7 @@ const GW_rom* load_game(uint8_t i_game){
         return gw_pack::game_at(i_game);
     }
 
-#if !defined(YOKOI_EXTERNAL_ROMPACK_ONLY)
+#if defined(YOKOI_EMBEDDED_ASSETS)
     if (i_game < nb_games) {
         return GW_list[i_game];
     }
@@ -33,7 +33,7 @@ size_t get_nb_name(){
     if (gw_pack::is_loaded()) {
         return gw_pack::game_count();
     }
-#if !defined(YOKOI_EXTERNAL_ROMPACK_ONLY)
+#if defined(YOKOI_EMBEDDED_ASSETS)
     return nb_games;
 #else
     return 0;


### PR DESCRIPTION
Remove ROMPACK style defines, replace with EMBEDDED, and reverse logic making the default build be rompack based. You need to use the EMBEDDED=1 flag to build with embedded resources