### PR TITLE
Add support for additional Elektronika games

### DIFF
--- a/CONVERT_ROM/GNW_LIST.md
+++ b/CONVERT_ROM/GNW_LIST.md
@@ -117,4 +117,5 @@ Special editions are not supported in the emulator, refer to the Notes column fo
 | 14  | IM-03   | taynyoke.zip        | Tayny okeana                                                 | 1988.01.01   | SM5A | gnw_octopus |
 | 15  | IM-04   | vespovar.zip        | Vesyolyy povar                                               | 1989.01.01   | SM5A | gnw_chef |
 | 16  | IM-22   | vfutbol.zip         | Vesyolye futbolisty                                          | 1989.01.01   | SM5A | gnw_mmouse |
-| 17  | IM-12   | vinnpukh.zip        | Vinni-Pukh                                                   | 199?         | SM511 | gnw_dkjrp |
+| 17  | IM-12   | vinnpukh.zip        | Vinni-Pukh (Panorama Screen)                                 | 199?         | SM511 | gnw_dkjrp | 
+| 01  | IM-23   | auslalom.zip        | Autoslalom                                                   | 1990.01.01   | SM5A |  |

--- a/source/std/GW_ALL_rgds.h
+++ b/source/std/GW_ALL_rgds.h
@@ -3,12 +3,16 @@
 
 #include "GW_ROM_RGDS/ataka_asteroidov.h"
 extern const GW_rom ataka_asteroidov;
+#include "GW_ROM_RGDS/autoslalom.h"
+extern const GW_rom autoslalom;
 #include "GW_ROM_RGDS/ball.h"
 extern const GW_rom ball;
 #include "GW_ROM_RGDS/balloon_fight_crystal_screen.h"
 extern const GW_rom balloon_fight_crystal_screen;
 #include "GW_ROM_RGDS/balloon_fight_new_wide_screen.h"
 extern const GW_rom balloon_fight_new_wide_screen;
+#include "GW_ROM_RGDS/biathlon.h"
+extern const GW_rom biathlon;
 #include "GW_ROM_RGDS/black_jack.h"
 extern const GW_rom black_jack;
 #include "GW_ROM_RGDS/bomb_sweeper.h"
@@ -17,6 +21,8 @@ extern const GW_rom bomb_sweeper;
 extern const GW_rom boxing;
 #include "GW_ROM_RGDS/chef.h"
 extern const GW_rom chef;
+#include "GW_ROM_RGDS/circus_elektronika.h"
+extern const GW_rom circus_elektronika;
 #include "GW_ROM_RGDS/clever_chicken.h"
 extern const GW_rom clever_chicken;
 #include "GW_ROM_RGDS/climber_crystal_screen.h"
@@ -59,10 +65,20 @@ extern const GW_rom green_house;
 extern const GW_rom helmet_version_cn_07;
 #include "GW_ROM_RGDS/helmet_version_cn_17.h"
 extern const GW_rom helmet_version_cn_17;
+#include "GW_ROM_RGDS/hockey_elektronika.h"
+extern const GW_rom hockey_elektronika;
 #include "GW_ROM_RGDS/judge_green_version.h"
 extern const GW_rom judge_green_version;
 #include "GW_ROM_RGDS/judge_purple_version.h"
 extern const GW_rom judge_purple_version;
+#include "GW_ROM_RGDS/kosmicheskiy_most.h"
+extern const GW_rom kosmicheskiy_most;
+#include "GW_ROM_RGDS/kosmicheskiy_polyot.h"
+extern const GW_rom kosmicheskiy_polyot;
+#include "GW_ROM_RGDS/kot_rybolov_elektronika.h"
+extern const GW_rom kot_rybolov_elektronika;
+#include "GW_ROM_RGDS/kvaka_zadavaka.h"
+extern const GW_rom kvaka_zadavaka;
 #include "GW_ROM_RGDS/life_boat.h"
 extern const GW_rom life_boat;
 #include "GW_ROM_RGDS/lion.h"
@@ -89,10 +105,18 @@ extern const GW_rom mickey_donald;
 extern const GW_rom mickey_mouse_panorama_screen;
 #include "GW_ROM_RGDS/mickey_mouse_wide_screen.h"
 extern const GW_rom mickey_mouse_wide_screen;
+#include "GW_ROM_RGDS/morskaja_ataka.h"
+extern const GW_rom morskaja_ataka;
+#include "GW_ROM_RGDS/nochnye_vorishki.h"
+extern const GW_rom nochnye_vorishki;
+#include "GW_ROM_RGDS/nu_pogodi.h"
+extern const GW_rom nu_pogodi;
 #include "GW_ROM_RGDS/octopus.h"
 extern const GW_rom octopus;
 #include "GW_ROM_RGDS/oil_panic.h"
 extern const GW_rom oil_panic;
+#include "GW_ROM_RGDS/okhota.h"
+extern const GW_rom okhota;
 #include "GW_ROM_RGDS/parachute.h"
 extern const GW_rom parachute;
 #include "GW_ROM_RGDS/pinball.h"
@@ -103,6 +127,8 @@ extern const GW_rom popeye_panorama_screen;
 extern const GW_rom popeye_wide_screen;
 #include "GW_ROM_RGDS/rain_shower.h"
 extern const GW_rom rain_shower;
+#include "GW_ROM_RGDS/razvedchiki_kosmosa.h"
+extern const GW_rom razvedchiki_kosmosa;
 #include "GW_ROM_RGDS/safe_buster.h"
 extern const GW_rom safe_buster;
 #include "GW_ROM_RGDS/shuttle_voyage.h"
@@ -129,6 +155,8 @@ extern const GW_rom super_goal_keeper;
 extern const GW_rom super_mario_bros_crystal_screen;
 #include "GW_ROM_RGDS/super_mario_bros_new_wide_screen.h"
 extern const GW_rom super_mario_bros_new_wide_screen;
+#include "GW_ROM_RGDS/tayny_okeana.h"
+extern const GW_rom tayny_okeana;
 #include "GW_ROM_RGDS/thief_in_garden.h"
 extern const GW_rom thief_in_garden;
 #include "GW_ROM_RGDS/thunder_ball_tronica.h"
@@ -139,12 +167,18 @@ extern const GW_rom tropical_fish;
 extern const GW_rom turtle_bridge;
 #include "GW_ROM_RGDS/vermin.h"
 extern const GW_rom vermin;
+#include "GW_ROM_RGDS/vesyolye_futbolisty.h"
+extern const GW_rom vesyolye_futbolisty;
+#include "GW_ROM_RGDS/vesyolyy_povar.h"
+extern const GW_rom vesyolyy_povar;
+#include "GW_ROM_RGDS/vinni_pukh_panorama_screen.h"
+extern const GW_rom vinni_pukh_panorama_screen;
 #include "GW_ROM_RGDS/zelda.h"
 extern const GW_rom zelda;
 
 
 
 
-const GW_rom* GW_list[] = {&ataka_asteroidov, &ball, &balloon_fight_crystal_screen, &balloon_fight_new_wide_screen, &black_jack, &bomb_sweeper, &boxing, &chef, &clever_chicken, &climber_crystal_screen, &climber_new_wide_screen, &crab_grab, &diver_s_adventure, &donkey_kong, &donkey_kong_3, &donkey_kong_circus, &donkey_kong_hockey, &donkey_kong_ii, &donkey_kong_jr_new_wide_screen, &donkey_kong_jr_panorama_screen, &egg, &fire_attack, &fire_silver, &fire_wide_screen, &flagman, &gold_cliff, &green_house, &helmet_version_cn_07, &helmet_version_cn_17, &judge_green_version, &judge_purple_version, &life_boat, &lion, &manhole_gold, &manhole_new_wide_screen, &mario_bros, &mario_s_bombs_away, &mario_s_cement_factory_new_wide_screen, &mario_s_cement_factory_table_top_cm_72, &mario_s_cement_factory_table_top_cm_72a, &mario_the_juggler, &mickey_donald, &mickey_mouse_panorama_screen, &mickey_mouse_wide_screen, &octopus, &oil_panic, &parachute, &pinball, &popeye_panorama_screen, &popeye_wide_screen, &rain_shower, &safe_buster, &shuttle_voyage, &snoopy_panorama_screen, &snoopy_tennis, &space_adventure, &space_mission_tronica, &space_rescue, &spider_tronica, &spitball_sparky, &squish, &super_goal_keeper, &super_mario_bros_crystal_screen, &super_mario_bros_new_wide_screen, &thief_in_garden, &thunder_ball_tronica, &tropical_fish, &turtle_bridge, &vermin, &zelda};
-const size_t nb_games = 70;
+const GW_rom* GW_list[] = {&ataka_asteroidov, &autoslalom, &ball, &balloon_fight_crystal_screen, &balloon_fight_new_wide_screen, &biathlon, &black_jack, &bomb_sweeper, &boxing, &chef, &circus_elektronika, &clever_chicken, &climber_crystal_screen, &climber_new_wide_screen, &crab_grab, &diver_s_adventure, &donkey_kong, &donkey_kong_3, &donkey_kong_circus, &donkey_kong_hockey, &donkey_kong_ii, &donkey_kong_jr_new_wide_screen, &donkey_kong_jr_panorama_screen, &egg, &fire_attack, &fire_silver, &fire_wide_screen, &flagman, &gold_cliff, &green_house, &helmet_version_cn_07, &helmet_version_cn_17, &hockey_elektronika, &judge_green_version, &judge_purple_version, &kosmicheskiy_most, &kosmicheskiy_polyot, &kot_rybolov_elektronika, &kvaka_zadavaka, &life_boat, &lion, &manhole_gold, &manhole_new_wide_screen, &mario_bros, &mario_s_bombs_away, &mario_s_cement_factory_new_wide_screen, &mario_s_cement_factory_table_top_cm_72, &mario_s_cement_factory_table_top_cm_72a, &mario_the_juggler, &mickey_donald, &mickey_mouse_panorama_screen, &mickey_mouse_wide_screen, &morskaja_ataka, &nochnye_vorishki, &nu_pogodi, &octopus, &oil_panic, &okhota, &parachute, &pinball, &popeye_panorama_screen, &popeye_wide_screen, &rain_shower, &razvedchiki_kosmosa, &safe_buster, &shuttle_voyage, &snoopy_panorama_screen, &snoopy_tennis, &space_adventure, &space_mission_tronica, &space_rescue, &spider_tronica, &spitball_sparky, &squish, &super_goal_keeper, &super_mario_bros_crystal_screen, &super_mario_bros_new_wide_screen, &tayny_okeana, &thief_in_garden, &thunder_ball_tronica, &tropical_fish, &turtle_bridge, &vermin, &vesyolye_futbolisty, &vesyolyy_povar, &vinni_pukh_panorama_screen, &zelda};
+const size_t nb_games = 87;
 

--- a/source/virtual_i_o/time_addresses.h
+++ b/source/virtual_i_o/time_addresses.h
@@ -31,17 +31,33 @@ inline const TimeAddress* get_time_addresses(const std::string& ref_game) {
         {"LN_08", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Lion
         {"PR_21", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Parachute
         {"OC_22", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Octopus
+        {"IM_03", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Tayny okeana
         {"PP_23", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Popeye (Wide Screen)
         {"IP_05", {1,2, 1,3, 1,6, 1,7, 1,4, 1,5, 0}}, // Judge (Green / Original)
         {"IP_15", {1,2, 1,3, 1,6, 1,7, 1,4, 1,5, 0}}, // Judge (Purple / Revised)
         {"FP_24", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Chef
+        {"IM_04", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Vesyolyy povar
         {"MC_25", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Mickey Mouse (Wide Screen)
         {"EG_26", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Egg
         {"IM_53", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Ataka asteroidov
+        {"IM_19", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Biathlon 
+        {"ECIRCUS", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Circus 
+        {"IM_10", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Hockey 
+        {"IM_50", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Kosmicheskiy polyot 
+        {"IM_32", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Kot-rybolov 
+        {"IM_33", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Kvaka-zadavaka 
+        {"IM_51", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Morskaja ataka 
+        {"IM_49", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Nochnye vorishki 
+        {"IM_02", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Nu, pogodi! 
+        {"IM_16", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Okhota 
+        {"IM_13", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Razvedchiki kosmosa 
+        {"IM_22", {2,4, 2,5, 2,6, 2,7, 2,8, 2,9, 2}}, // Vesyolye futbolisty 
         {"FR_27", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Fire (Wide Screen)
+        {"IM_09", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Kosmicheskiy most
         {"SK_10", {0,3, 0,2, 0,1, 0,0, 99,99, 99,99, 8}}, // Super Goal Keeper
         {"SM_11", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Space Mission (Tronica)
         {"SG_21", {3,6, 3,7, 3,8, 3,9, 3,10, 3,11, 8}}, // Spider (Tronica)
+        {"IM_23", {2,4, 2,5, 2,6, 2,7, 99,99, 99,99, 0}}, // Autoslalom (Elektronika) 
     };
 
     // --- SM510 ---
@@ -61,6 +77,7 @@ inline const TimeAddress* get_time_addresses(const std::string& ref_game) {
         {"SM_91", {1,4, 1,5, 1,6, 1,7, 1,8, 1,9, 8}}, // Snoopy (Panorama Screen)
         {"PG_92", {1,4, 1,5, 1,6, 1,7, 1,8, 1,9, 8}}, // Popeye (Panorama Screen)
         {"CJ_93", {1,4, 1,5, 1,6, 1,7, 1,8, 1,9, 8}}, // Donkey Kong Jr. (Panorama Screen)
+        {"IM_12", {1,4, 1,5, 1,6, 1,7, 1,8, 1,9, 8}}, // Vinni-Pukh (Panorama Screen)
         {"TB_94", {1,4, 1,5, 1,6, 1,7, 1,8, 1,9, 8}}, // Mario's Bombs Away
         {"DC_95", {1,4, 1,5, 1,6, 1,7, 1,8, 1,9, 8}}, // Donkey Kong Circus
         {"MK_96", {1,4, 1,5, 1,6, 1,7, 1,8, 1,9, 8}}, // Mickey Mouse (Panorama Screen)

--- a/source/virtual_i_o/virtual_input.h
+++ b/source/virtual_i_o/virtual_input.h
@@ -154,7 +154,7 @@ class MT_03 : public Virtual_Input{
 };
 
 
-////// Fire (first version) : SM5A //////
+////// Fire (first version) / Kosmicheskiy most : SM5A //////
 class RC_04 : public Virtual_Input{
     public : 
         RC_04(SM5XX* c) : Virtual_Input(c) {
@@ -429,7 +429,9 @@ class FP_24 : public Virtual_Input{
         }
 };
 
-////// Mickey_Mouse/Egg/Ataka asteroidov : SM5A //////
+////// Mickey_Mouse/Egg/Ataka asteroidov/Biathlon/Circus/Hockey/Kosmicheskiy polyot/Kot-rybolov/
+////// Kvaka-zadavaka/Morskaja ataka/Nochnye vorishki/Nu, pogodi!/Okhota/Razvedchiki kosmosa/
+////// Vesyolye futbolisty : SM5A //////
 class MC_25 : public Virtual_Input{
     public : 
         MC_25(SM5XX* c) : Virtual_Input(c) {
@@ -545,6 +547,37 @@ class SK_10 : public Virtual_Input{
                     switch (button) {
                         case BUTTON_UP: cpu->input_set(3, 1, state); break;
                         case BUTTON_DOWN: cpu->input_set(3, 0, state); break;
+                        default: break; } break;
+                default: break;
+            }
+        }
+};
+
+////// Autoslalom IM_23 : SM5A //////
+class IM_23 : public Virtual_Input{
+    public : 
+        IM_23(SM5XX* c) : Virtual_Input(c) {
+            left_configuration = CONF_2_BUTTON_UPDOWN;
+            right_configuration = CONF_2_BUTTON_UPDOWN;
+        }
+
+        void set_input(uint8_t part, uint8_t button, bool state, uint8_t player = 1) override{
+            switch (part) {
+                case PART_SETUP:
+                    switch (button) {
+                        case BUTTON_GAMEA: cpu->input_set(3, 2, state); break;
+                        case BUTTON_GAMEB: cpu->input_set(3, 1, state); break;
+                        case BUTTON_TIME: cpu->input_set(3, 0, state); break;
+                        default: break; } break;
+                case PART_LEFT:
+                    switch (button) {
+                        case BUTTON_UP: cpu->input_set(2, 1, state); break;
+                        case BUTTON_DOWN: cpu->input_set(2, 2, state); break;
+                        default: break; } break;
+                case PART_RIGHT:
+                    switch (button) {
+                        case BUTTON_UP: cpu->input_set(2, 3, state); break;
+                        case BUTTON_DOWN: cpu->input_set(2, 0, state); break;
                         default: break; } break;
                 default: break;
             }
@@ -1839,13 +1872,18 @@ inline Virtual_Input* get_input_config(SM5XX* cpu, std::string ref_game){
     else if (ref_game == "CN_07" || ref_game == "CN_17") { return new CN_07(cpu); } // Helmet    
     else if (ref_game == "LN_08") { return new LN_08(cpu); } // Lion
     else if (ref_game == "PR_21") { return new PR_21(cpu); } // Parachute
-    else if (ref_game == "OC_22") { return new OC_22(cpu); } // Octopus
+    else if (ref_game == "OC_22" || ref_game == "IM_03") { return new OC_22(cpu); } // Octopus / Tayny okeana
     else if (ref_game == "PP_23") { return new PP_23(cpu); } // Popeye
-    else if (ref_game == "FP_24") { return new FP_24(cpu); } // Chef
+    else if (ref_game == "FP_24" || ref_game == "IM_04") { return new FP_24(cpu); } // Chef / Vesyolyy povar
     else if (ref_game == "MC_25" || ref_game == "EG_26" || ref_game == "IM_53") { return new MC_25(cpu); } // Mickey Mouse / Egg / Ataka asteroidov
-    else if (ref_game == "FR_27") { return new FR_27(cpu); } // Fire (Wide Screen)
+    else if (ref_game == "IM_19" || ref_game == "ECIRCUS" || ref_game == "IM_10") { return new MC_25(cpu); } // Biathlon / Circus / Hockey
+    else if (ref_game == "IM_50" || ref_game == "IM_32" || ref_game == "IM_33") { return new MC_25(cpu); } // Kosmicheskiy polyot / Kot-rybolov / Kvaka-zadavaka
+    else if (ref_game == "IM_51" || ref_game == "IM_49" || ref_game == "IM_02") { return new MC_25(cpu); } // Morskaja ataka / Nochnye vorishki / Nu, pogodi!
+    else if (ref_game == "IM_16" || ref_game == "IM_13" || ref_game == "IM_22") { return new MC_25(cpu); } // Okhota / Razvedchiki kosmosa / Vesyolye futbolisty
+    else if (ref_game == "FR_27" || ref_game == "IM_09") { return new FR_27(cpu); } // Fire (Wide Screen) / Kosmicheskiy most
     else if (ref_game == "SM_11" || ref_game == "SG_21") { return new SM_11(cpu); } // Space Mission / Spider (Tronica)
     else if (ref_game == "SK_10") { return new SK_10(cpu); } // Super Goal Keeper (Tronica)
+    else if (ref_game == "IM_23") { return new IM_23(cpu); } // Autoslalom (Elektronika)
 
     /* SM510 */
     else if (ref_game == "TL_28") { return new TL_28(cpu); } // Turtle Bridge
@@ -1882,7 +1920,7 @@ inline Virtual_Input* get_input_config(SM5XX* cpu, std::string ref_game){
     else if (ref_game == "CM_72" || ref_game == "CM_72A") { return new CM_72(cpu); } // Mario's Cement Factory
     else if (ref_game == "SM_91") { return new SM_91(cpu); } // Snoopy (table top)
     else if (ref_game == "PG_92") { return new PG_92(cpu); } // Popeye (table top)
-    else if (ref_game == "CJ_93") { return new CJ_93(cpu); } // DK JR (Panorama)
+    else if (ref_game == "CJ_93" || ref_game == "IM_12") { return new CJ_93(cpu); } // DK JR (Panorama) / Vinni-Pukh
     else if (ref_game == "TB_94") { return new TB_94(cpu); } // Mario's Bombs Away
     else if (ref_game == "DC_95" || ref_game == "MK_96") { return new DC_95(cpu); } // Donkey Kong Circus / Mickey Mouse
     else if (ref_game == "YM_801" || ref_game == "YM_105") { return new YM_801(cpu); } // Super Mario Bros


### PR DESCRIPTION
Biathlon, Circus (Elektronika), Hockey (Elektronika), Kosmicheskiy most, Kosmicheskiy polyot, Kot-rybolov (Elektronika), Kvaka-zadavaka, Morskaja ataka, Nochnye vorishki, Nu, pogodi!, Okhota, Razvedchiki kosmosa, Tayny okeana, Vesyolyy povar, Vesyolye futbolisty, Vinni-Pukh (Panorama Screen), Autoslalom